### PR TITLE
Error out on missing parameter to `bump'.

### DIFF
--- a/src/semver
+++ b/src/semver
@@ -197,10 +197,11 @@ function command-bump {
           shift 2
         fi ;;
       --pretend|-p) pretend=1; shift ;;
-      "") break;;
       *) usage-help ;;
     esac
   done
+
+  [ -z "${new:-}" ] && usage-help
 
   if [[ "$pretend" -eq 1 ]]; then
     echo $new
@@ -236,7 +237,6 @@ function command-release {
           shift 2
         fi ;;
       --pretend|-p) pretend=1; shift ;;
-      "") break;;
       *) usage-help ;;
     esac
   done


### PR DESCRIPTION
Also, disallow passing empty parameters. This was introduced in
32eda1cad91699549ad2341f6bd6e296f9a48e5b, and I don't see cases where
it is useful. Perhaps I'm missing something.
