### PR TITLE
Add a tag in git if version gets bumped

### DIFF
--- a/src/semver
+++ b/src/semver
@@ -135,9 +135,10 @@ function git-entry {
       echo "Working directory not clean. Cannot create tag / commit."
       return
     fi
+    tag=v"$1"
     git add .version
-    git tag "$1" -am "$1"
-    git commit -m "$1"
+    git tag "$tag" -am "$tag"
+    git commit -m "$tag"
   fi
 }
 

--- a/src/semver
+++ b/src/semver
@@ -43,9 +43,9 @@ Options:
   -h, --help             Print this help message.
 
 Commands:
-  init     initialize this project's version.
+  init     initialize this project's version. If it finds a .git directory, it will also create a tag with the version.
   bump     this project's version by one of major, minor, patch, prerel, build
-           or a forced potentialy conflicting version.
+           or a forced potentialy conflicting version. If it finds a .git directory, it will also create a tag with the version.
   compare  <version> to this project's version or to provided <oldversion>."
 
 
@@ -129,6 +129,18 @@ function cli-print {
   exit 0
 }
 
+function git-entry {
+  if [ -d ".git" ]; then
+    if [ ! -z "$(git status --porcelain | grep -v .version)" ]; then 
+      echo "Working directory not clean. Cannot create tag / commit."
+      return
+    fi
+    git add .version
+    git tag "$1"
+    git commit -m "$1"
+  fi
+}
+
 function command-init {
   local version=""
   case $# in
@@ -142,6 +154,7 @@ function command-init {
   fi
 
   echo "$version" | tee "$VERSION_FILE"
+  git-entry $version
   exit 0
 }
 
@@ -189,6 +202,7 @@ function command-bump {
     echo $new
   else
     echo $new | tee $VERSION_FILE
+    git-entry $new
   fi
   exit 0
 }

--- a/src/semver
+++ b/src/semver
@@ -137,8 +137,8 @@ function git-entry {
     fi
     tag=v"$1"
     git add .version
-    git tag "$tag" -am "$tag"
     git commit -m "$tag"
+    git tag "$tag" -am "$tag"
   fi
 }
 

--- a/src/semver
+++ b/src/semver
@@ -136,7 +136,7 @@ function git-entry {
       return
     fi
     git add .version
-    git tag "$1"
+    git tag "$1" -am "$1"
     git commit -m "$1"
   fi
 }
@@ -166,6 +166,7 @@ function command-bump {
   local patch=${split[2]}
   local prere=${split[3]}
   local build=${split[4]}
+  local new=""
   while [[ $# -gt 0 ]]; do
     case "$1" in
       major) new="$(($major + 1)).0.0"; shift ;;
@@ -197,6 +198,12 @@ function command-bump {
       *) usage-help ;;
     esac
   done
+
+  if [ -z "$new" ]; then
+      echo "Missing version information"
+      usage-help
+      exit 1
+  fi
 
   if [[ "$pretend" -eq 1 ]]; then
     echo $new


### PR DESCRIPTION
If semver-tool detects a .git directory, it will add an annotated tag to git and commit it if the version number gets initialised or bumped. 
I really liked this feature in npm and thought it might be a nice addition in semver-tool.