### PR TITLE
Remove un-used code and fixes linting issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ follows the [semver] specification. Its use are:
 It can be combined `git` pre-commit hooks to guarantee a correct versioning.
 
 [semver]: https://github.com/mojombo/semver
-[gitflow]: https://github.com/nvie/gitflow
 
 [![Build Status](https://travis-ci.org/fsaintjacques/semver-tool.svg?branch=master)](https://travis-ci.org/fsaintjacques/semver-tool)
 [![Stable Version](https://img.shields.io/github/tag/fsaintjacques/semver-tool.svg)](https://github.com/fsaintjacques/semver-tool/tree/2.0.0)

--- a/src/semver
+++ b/src/semver
@@ -7,9 +7,6 @@ SEMVER_REGEX="^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-]+
 PROG=semver
 PROG_VERSION=2.0.0
 
-VERSION_FILE=${VERSION_FILE:-.version}
-DEFAULT_VERSION=0.1.0
-
 USAGE="\
 Usage:
   $PROG bump (major|minor|patch|prerel <prerel>|build <build>) <version>
@@ -45,10 +42,6 @@ Commands:
            following values: -1 if <other_version> is newer, 0 if equal, 1 if
            older."
 
-
-function warning {
-  echo -e "$1" >&2
-}
 
 function error {
   echo -e "$1" >&2
@@ -128,23 +121,23 @@ function command-bump {
     *) usage-help;;
   esac
 
-  validate-version $version split
-  local major=${split[0]}
-  local minor=${split[1]}
-  local patch=${split[2]}
-  local prere=${split[3]}
-  local build=${split[4]}
+  validate-version "$version" parts
+  local major="${parts[0]}"
+  local minor="${parts[1]}"
+  local patch="${parts[2]}"
+  local prere="${parts[3]}"
+  local build="${parts[4]}"
 
   case "$command" in
-    major) new="$(($major + 1)).0.0";;
-    minor) new="${major}.$(($minor + 1)).0";;
-    patch) new="${major}.${minor}.$(($patch + 1))";;
+    major) new="$((major + 1)).0.0";;
+    minor) new="${major}.$((minor + 1)).0";;
+    patch) new="${major}.${minor}.$((patch + 1))";;
     prerel) new=$(validate-version "${major}.${minor}.${patch}-${sub_version}");;
     build) new=$(validate-version "${major}.${minor}.${patch}${prere}+${sub_version}");;
     *) usage-help ;;
   esac
 
-  echo $new
+  echo "$new"
   exit 0
 }
 
@@ -156,18 +149,18 @@ function command-compare {
     *) usage-help ;;
   esac
 
-  echo $(compare-version "$v" "$v_")
+  compare-version "$v" "$v_"
   exit 0
 }
 
 case $# in
-  0) cli-print ;;
+  0) echo "Unknown command: $*"; usage-help;;
 esac
 
 case $1 in
   --help|-h) echo -e "$USAGE"; exit 0;;
   --version|-v) usage-version ;;
-  bump) shift; command-bump $@;;
-  compare) shift; command-compare $@;;
-  *) echo "Unknown arguments: $@"; usage-help;;
+  bump) shift; command-bump "$@";;
+  compare) shift; command-compare "$@";;
+  *) echo "Unknown arguments: $*"; usage-help;;
 esac

--- a/test/documentation-test
+++ b/test/documentation-test
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-BASENAME=$(basename "$0")
-SEMVER_HOME="$(cd "$(dirname "$(which $0)")/.." >/dev/null; pwd -P)"
+SEMVER_HOME="$(cd "$(dirname "$(which "$0")")/.." >/dev/null; pwd -P)"
 
 SEMVER=$SEMVER_HOME/src/semver
 README=$SEMVER_HOME/README.md
@@ -22,12 +21,11 @@ list_tests |
   while read -r unit_test; do
     expected_result=$(expected_result_for_test "$unit_test")
     # make test invoke ../src/semver
-    eval_test=$(echo $unit_test | sed -e 's#^semver#'$SEMVER'#')
-    actual_result=$($eval_test)
+    actual_result=$($(echo "${unit_test//semver/$SEMVER}"))
 
     if [[ "$actual_result" != "$expected_result" ]]; then
         echo "Test failed: $unit_test"
-        echo "Expected " $expected_result " but got " $actual_result
+        echo "Expected " "$expected_result" " but got " "$actual_result"
         exit 1
     fi
   done


### PR DESCRIPTION
Some un-used code was left over as part of the changes for v2.0.0
this change removes the remnants.

Also used [shellcheck](http://www.shellcheck.net/) to lint the code
and applied the code changes to resolve the identified issues.

One notable item was due to the use of a variable `split` which is an
actual bash command [split](https://ss64.com/bash/split.html). The
variable was renamed to `parts`.