### PR TITLE
Add lint check to Makefile and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,13 @@
+sudo: required
+
+services:
+  - docker
+
 language: c
-script: make test
+
+before_install:
+  - docker pull koalaman/shellcheck
+
+script:
+  - make lint
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
+ROOT ?= $(shell pwd)
+
 test:
 	test/documentation-test
+
+lint:
+	docker run --rm -v ${ROOT}:/mnt koalaman/shellcheck src/semver
+	docker run --rm -v ${ROOT}:/mnt koalaman/shellcheck test/documentation-test
 
 install:
 	install src/semver /usr/local/bin
 
-.PHONY: test install
+.PHONY: test install lint

--- a/src/semver
+++ b/src/semver
@@ -122,6 +122,7 @@ function command-bump {
   esac
 
   validate-version "$version" parts
+  # shellcheck disable=SC2154
   local major="${parts[0]}"
   local minor="${parts[1]}"
   local patch="${parts[2]}"

--- a/test/documentation-test
+++ b/test/documentation-test
@@ -21,7 +21,7 @@ list_tests |
   while read -r unit_test; do
     expected_result=$(expected_result_for_test "$unit_test")
     # make test invoke ../src/semver
-    actual_result=$($(echo "${unit_test//semver/$SEMVER}"))
+    actual_result=$(${unit_test//semver/$SEMVER})
 
     if [[ "$actual_result" != "$expected_result" ]]; then
         echo "Test failed: $unit_test"


### PR DESCRIPTION
Adds lint task to Makefile
Adds use of `make lint` to travis via docker service.

Resolves the last lint issue within test script.
Adds ignore only lint issue within semver. The lint issue is because
the variable is set using `eval` in another function which results
in shellcheck being unable to determine when/if the variable `parts`
was initiatlized with a value.