### PR TITLE
Add customizable PREFIX in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ lint:
 	docker run --rm -v ${ROOT}:/mnt koalaman/shellcheck test/documentation-test
 
 install:
-	install src/semver ${PREFIX}/bin
+	install src/semver ${DESTDIR}${PREFIX}/bin
 
 .PHONY: test install lint

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PREFIX ?= /usr/local
 ROOT ?= $(shell pwd)
 
 test:
@@ -8,6 +9,6 @@ lint:
 	docker run --rm -v ${ROOT}:/mnt koalaman/shellcheck test/documentation-test
 
 install:
-	install src/semver /usr/local/bin
+	install src/semver ${PREFIX}/bin
 
 .PHONY: test install lint


### PR DESCRIPTION
The user of this package won't necessarily want to install to `/usr/local` (indeed, that directory doesn't even exist on my system). Additionally, package managers would probably like to install the program elsewhere ([example][1]), and without a way to customize the prefix would have to fall back to either patching the Makefile, or doing the installation manually, both of which might break down the line.

By introducing a `PREFIX` variable with a default value of `/usr/local`, the installation prefix can be customized, solving these problems.

[1]: https://github.com/NixOS/nixpkgs/pull/51004