### PR TITLE
Fixed compare 'version' with 'version-prerelease' and documentation-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Basic bumping operations
 Comparing version for scripting
 
     $ semver compare 1.0.1-rc1.1.0+build.051 1.0.1
-    1
+    -1
     $ semver compare 1.0.1-rc1.1.0+build.051 1.0.1-rc1.1.0
     0
     $ semver compare 1.0.1-rc1.1.0+build.051 1.0.1-rc1.1.0+build.052

--- a/src/semver
+++ b/src/semver
@@ -96,9 +96,9 @@ function compare-version {
 
   # PREREL should compare with the ASCII order.
   if [[ -z "${V[3]}" ]] && [[ -n "${V_[3]}" ]]; then
-    echo -1; return 0;
-  elif [[ -n "${V[3]}" ]] && [[ -z "${V_[3]}" ]]; then
     echo 1; return 0;
+  elif [[ -n "${V[3]}" ]] && [[ -z "${V_[3]}" ]]; then
+    echo -1; return 0;
   elif [[ -n "${V[3]}" ]] && [[ -n "${V_[3]}" ]]; then
     if [[ "${V[3]}" > "${V_[3]}" ]]; then
       echo 1; return 0;

--- a/test/documentation-test
+++ b/test/documentation-test
@@ -13,7 +13,7 @@ function list_tests() {
 
 function expected_result_for_test() {
   local test=$1
-  grep -A1 "$test" "$README" | tail -1 | sed -e 's/^ *//'
+  grep -A1 "$test\$" "$README" | tail -1 | sed -e 's/^ *//'
 }
 
 


### PR DESCRIPTION
Hello,

Due to #27 I've fixed the issue and corresponding test. Also I added '\$' to uniquely match unit test case.