### PR TITLE
Update documentation to specify semver 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ The semver shell utility
 ========================
 
 semver is a little tool to manipulate version bumping in a project that
-follows the [semver] specification. Its use are:
+follows the [semver 2.x][semver] specification. Its use are:
 
   - bump version
   - compare version

--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Comparing version for scripting
     1
     $ semver compare 10.1.4-rc4 10.4.2-rc1
     -1
+    $ semver compare 10.1.4-rc4 10.4.2-01234
+    -1
 
 Extract version part
 
@@ -109,3 +111,9 @@ Extract version part
     alpha.4.5
     $ semver get build 1.2.3-rc.4+build.567
     build.567
+    $ semver get prerel 1.2.3+build.568
+    
+    $ semver get prerel 1.2.3-rc.4+build.569
+    rc.4
+    $ semver get prerel 1.2.3-rc-4+build.570
+    rc-4

--- a/src/semver
+++ b/src/semver
@@ -62,6 +62,10 @@ function usage-version {
 
 function validate-version {
   local version=$1
+  # TODO: semver 2.x also restricts numeric prerel as follows:
+  #   > Numeric identifiers MUST NOT include leading zeroes.
+  #   No definition of "numeric identifiers" is given by semver 2.x.
+  #   This restriction is not yet implemented by this script.
   if [[ "$version" =~ $SEMVER_REGEX ]]; then
     # if a second argument is passed, store the result in var named by $2
     if [ "$#" -eq "2" ]; then

--- a/src/semver
+++ b/src/semver
@@ -20,15 +20,15 @@ Arguments:
              \"${SEMVER_REGEX}\".
              In english, the version must match X.Y.Z(-PRERELEASE)(+BUILD)
              where X, Y and Z are positive integers, PRERELEASE is an optional
-             string composed of alphanumeric characters and hyphens and
+             string composed of alphanumeric characters, dots and hyphens and
              BUILD is also an optional string composed of alphanumeric
-             characters and hyphens.
+             characters, dots and hyphens.
 
   <other_version>  See <version> definition.
 
-  <prerel>  String that must be composed of alphanumeric characters and hyphens.
+  <prerel>  String that must be composed of alphanumeric characters, dots and hyphens.
 
-  <build>   String that must be composed of alphanumeric characters and hyphens.
+  <build>   String that must be composed of alphanumeric characters, dots and hyphens.
 
 Options:
   -v, --version          Print the version of this tool.

--- a/test/documentation-test
+++ b/test/documentation-test
@@ -16,6 +16,9 @@ function expected_result_for_test() {
   grep -A1 "$test\$" "$README" | tail -1 | sed -e 's/^ *//'
 }
 
+# TODO: how to assert that certain input versions will fail the version-check?
+#   for example the command `semver get major 01.2.3`
+#   must fail, as the given version is not valid.
 
 list_tests |
   while read -r unit_test; do


### PR DESCRIPTION
Fixes #29 

* add TODO: test/documentation-test should also allow testing error-cases.
* add TODO: validation-version does not fully implement semver2.x with regards to numerical prerel identifiers
* fix code comments: prerel and build also allow dots.
* document that semver 2.x is implemented as opposed to semver 1.x or a future version.

