### PR TITLE
"release" subcommand fixed for "get", documentation updated/corrected

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ usage
 
 ```
 Usage:
-  semver bump (major|minor|patch|prerel <prerel>|build <build>) <version>
+  semver bump (major|minor|patch|release|prerel <prerel>|build <build>) <version>
   semver compare <version> <other_version>
   semver get (major|minor|patch|release|prerel|build) <version>
   semver --help
@@ -30,9 +30,9 @@ Usage:
 
 Arguments:
   <version>  A version must match the following regex pattern:
-             \"${SEMVER_REGEX}\".
+             "^[vV]?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$".
              In english, the version must match X.Y.Z(-PRERELEASE)(+BUILD)
-             where X, Y and Z are positive integers, PRERELEASE is an optionnal
+             where X, Y and Z are positive integers, PRERELEASE is an optional
              string composed of alphanumeric characters and hyphens and
              BUILD is also an optional string composed of alphanumeric
              characters and hyphens.
@@ -49,7 +49,7 @@ Options:
 
 Commands:
   bump     Bump <version> by one of major, minor, patch, prerel, build
-           or a forced potentialy conflicting version. The bumped version is
+           or a forced potentially conflicting version. The bumped version is
            shown to stdout.
 
   compare  Compare <version> with <other_version>, output to stdout the
@@ -109,3 +109,5 @@ Extract version part
     alpha.4.5
     $ semver get build 1.2.3-rc.4+build.567
     build.567
+    $ semver get release 1.2.3-rc.4+build.567
+    1.2.3

--- a/src/semver
+++ b/src/semver
@@ -177,6 +177,7 @@ function command-get {
     local patch="${parts[2]}"
     local prerel="${parts[3]:1}"
     local build="${parts[4]:1}"
+    local release="${major}.${minor}.${patch}"
 
     case "$part" in
         major|minor|patch|release|prerel|build) echo "${!part}" ;;


### PR DESCRIPTION
The "release" subcommand now works correctly with the "get" command.
It works as specified in the public API for semver 2.1.0 (README.md),
so this change does not impact the public API: it is a bug fix. An
example and test case has been added to the README.md to cover "get
release".

The public documentation for semver 2.1.0 does not specify a "bump
release" command. However, an example of this command is present in
the 2.1.0 README.md and "bump release" is specified in the script usage
message. Assuming this, the change to the public documentation in this
commit should not be considered as changing the public API (again, this
is a documentation bug fix, not a minor version increment).

README.md has been updated to correspond exactly to the script's usage
message. Not only is the release subcommand correctly documented, but
two spelling errors have been corrected and the regular expression has
been expanded.

Addresses github issue #33 