### PR TITLE
semver tool compliant with semver.org spec version 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ follows the [semver 2.x][semver] specification. Its use are:
   - compare version
   - extract specific version part
 
-It can be combined `git` pre-commit hooks to guarantee a correct versioning.
+It can be combined with `git` pre-commit hooks to guarantee correct versioning.
 
 [semver]: https://github.com/mojombo/semver
 
@@ -29,35 +29,44 @@ Usage:
   semver --version
 
 Arguments:
-  <version>  A version must match the following regex pattern:
-             "^[vV]?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$".
-             In english, the version must match X.Y.Z(-PRERELEASE)(+BUILD)
-             where X, Y and Z are positive integers, PRERELEASE is an optional
-             string composed of alphanumeric characters and hyphens and
-             BUILD is also an optional string composed of alphanumeric
-             characters and hyphens.
+  <version>  A version must match the following regular expression:
+             "^[vV]?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
+             In English:
+	     -- The version must match X.Y.Z[-PRERELEASE][+BUILD]
+                where X, Y and Z are non-negative integers.
+	     -- PRERELEASE is a dot separated sequence of non-negative integers and/or
+	        identifiers composed of alphanumeric characters and hyphens (with
+		at least one non-digit). Numeric identifiers must not have leading
+		zeros. A hyphen ("-") introduces this optional part.
+	     -- BUILD is a dot separated sequence of identifiers composed of alphanumeric
+	        characters and hyphens. A plus ("+") introduces this optional part.
 
   <other_version>  See <version> definition.
 
-  <prerel>  String that must be composed of alphanumeric characters and hyphens.
+  <prerel>  A string as defined by PRERELEASE above.
 
-  <build>   String that must be composed of alphanumeric characters and hyphens.
+  <build>   A string as defined by BUILD above.
 
 Options:
   -v, --version          Print the version of this tool.
   -h, --help             Print this help message.
 
 Commands:
-  bump     Bump <version> by one of major, minor, patch, prerel, build
-           or a forced potentially conflicting version. The bumped version is
-           shown to stdout.
+  bump     Bump by one of major, minor, patch; zeroing or removing
+           subsequent parts. "bump prerel" sets the PRERELEASE part and
+	   removes any BUILD part. "bump build" sets the BUILD part.
+	   "bump release" removes any PRERELEASE or BUILD parts.
+           The bumped version is written to stdout.
 
   compare  Compare <version> with <other_version>, output to stdout the
            following values: -1 if <other_version> is newer, 0 if equal, 1 if
-           older.
+           older. The BUILD part is not used in comparisons.
 
   get      Extract given part of <version>, where part is one of major, minor,
-           patch, prerel, build.
+           patch, prerel, build, or release.
+
+See also:
+  https://semver.org -- Semantic Versioning 2.0.0
 ```
 
 examples
@@ -79,14 +88,14 @@ Basic bumping operations
     1.0.1-rc1.1.0
     $ semver bump build build.051 1.0.1-rc1.1.0
     1.0.1-rc1.1.0+build.051
-    $ semver bump release 0.1.0-SNAPSHOT
+    $ semver bump release v0.1.0-SNAPSHOT
     0.1.0
 
 Comparing version for scripting
 
     $ semver compare 1.0.1-rc1.1.0+build.051 1.0.1
     -1
-    $ semver compare 1.0.1-rc1.1.0+build.051 1.0.1-rc1.1.0
+    $ semver compare v1.0.1-rc1.1.0+build.051 V1.0.1-rc1.1.0
     0
     $ semver compare 1.0.1-rc1.1.0+build.051 1.0.1-rc1.1.0+build.052
     0
@@ -94,7 +103,7 @@ Comparing version for scripting
     1
     $ semver compare 10.1.4-rc4 10.4.2-rc1
     -1
-    $ semver compare 10.1.4-rc4 10.4.2-01234
+    $ semver compare 10.1.4-rc4 10.4.2-1234
     -1
 
 Extract version part

--- a/README.md
+++ b/README.md
@@ -32,14 +32,14 @@ Arguments:
   <version>  A version must match the following regular expression:
              "^[vV]?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(\-(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$"
              In English:
-	     -- The version must match X.Y.Z[-PRERELEASE][+BUILD]
+             -- The version must match X.Y.Z[-PRERELEASE][+BUILD]
                 where X, Y and Z are non-negative integers.
-	     -- PRERELEASE is a dot separated sequence of non-negative integers and/or
-	        identifiers composed of alphanumeric characters and hyphens (with
-		at least one non-digit). Numeric identifiers must not have leading
-		zeros. A hyphen ("-") introduces this optional part.
-	     -- BUILD is a dot separated sequence of identifiers composed of alphanumeric
-	        characters and hyphens. A plus ("+") introduces this optional part.
+             -- PRERELEASE is a dot separated sequence of non-negative integers and/or
+                identifiers composed of alphanumeric characters and hyphens (with
+                at least one non-digit). Numeric identifiers must not have leading
+                zeros. A hyphen ("-") introduces this optional part.
+             -- BUILD is a dot separated sequence of identifiers composed of alphanumeric
+                characters and hyphens. A plus ("+") introduces this optional part.
 
   <other_version>  See <version> definition.
 
@@ -54,8 +54,8 @@ Options:
 Commands:
   bump     Bump by one of major, minor, patch; zeroing or removing
            subsequent parts. "bump prerel" sets the PRERELEASE part and
-	   removes any BUILD part. "bump build" sets the BUILD part.
-	   "bump release" removes any PRERELEASE or BUILD parts.
+           removes any BUILD part. "bump build" sets the BUILD part.
+           "bump release" removes any PRERELEASE or BUILD parts.
            The bumped version is written to stdout.
 
   compare  Compare <version> with <other_version>, output to stdout the

--- a/src/semver
+++ b/src/semver
@@ -28,14 +28,14 @@ Arguments:
   <version>  A version must match the following regular expression:
              \"${SEMVER_REGEX}\"
              In English:
-	     -- The version must match X.Y.Z[-PRERELEASE][+BUILD]
+             -- The version must match X.Y.Z[-PRERELEASE][+BUILD]
                 where X, Y and Z are non-negative integers.
-	     -- PRERELEASE is a dot separated sequence of non-negative integers and/or
-	        identifiers composed of alphanumeric characters and hyphens (with
-		at least one non-digit). Numeric identifiers must not have leading
-		zeros. A hyphen (\"-\") introduces this optional part.
-	     -- BUILD is a dot separated sequence of identifiers composed of alphanumeric
-	        characters and hyphens. A plus (\"+\") introduces this optional part.
+             -- PRERELEASE is a dot separated sequence of non-negative integers and/or
+                identifiers composed of alphanumeric characters and hyphens (with
+                at least one non-digit). Numeric identifiers must not have leading
+                zeros. A hyphen (\"-\") introduces this optional part.
+             -- BUILD is a dot separated sequence of identifiers composed of alphanumeric
+                characters and hyphens. A plus (\"+\") introduces this optional part.
 
   <other_version>  See <version> definition.
 
@@ -50,8 +50,8 @@ Options:
 Commands:
   bump     Bump by one of major, minor, patch; zeroing or removing
            subsequent parts. \"bump prerel\" sets the PRERELEASE part and
-	   removes any BUILD part. \"bump build\" sets the BUILD part.
-	   \"bump release\" removes any PRERELEASE or BUILD parts.
+           removes any BUILD part. \"bump build\" sets the BUILD part.
+           \"bump release\" removes any PRERELEASE or BUILD parts.
            The bumped version is written to stdout.
 
   compare  Compare <version> with <other_version>, output to stdout the
@@ -80,10 +80,6 @@ function usage-version {
 
 function validate-version {
   local version=$1
-  # TODO: semver 2.x also restricts numeric prerel as follows:
-  #   > Numeric identifiers MUST NOT include leading zeroes.
-  #   No definition of "numeric identifiers" is given by semver 2.x.
-  #   This restriction is not yet implemented by this script.
   if [[ "$version" =~ $SEMVER_REGEX ]]; then
     # if a second argument is passed, store the result in var named by $2
     if [ "$#" -eq "2" ]; then
@@ -101,21 +97,21 @@ function validate-version {
   fi
 }
 
-function isNAT {
+function is-nat {
     [[ "$1" =~ ^($NAT)$ ]]
 }
 
-function isNULL {
+function is-null {
     [ -z "$1" ]
 }
 
-function orderNAT {
+function order-nat {
     [ "$1" -lt "$2" ] && { echo -1 ; return ; }
     [ "$1" -gt "$2" ] && { echo 1 ; return ; }
     echo 0
 }
 
-function orderSTRING {
+function order-string {
     [[ $1 < $2 ]] && { echo -1 ; return ; }
     [[ $1 > $2 ]] && { echo 1 ; return ; }
     echo 0
@@ -139,24 +135,24 @@ function compare-fields {
 
     while true
     do
-	[ $order -ne 0 ] && { echo $order ; return ; }
+        [ $order -ne 0 ] && { echo $order ; return ; }
 
-	: $(( i++ ))
-	left="${leftfield[$i]}"
-	right="${rightfield[$i]}"
+        : $(( i++ ))
+        left="${leftfield[$i]}"
+        right="${rightfield[$i]}"
 
-	isNULL "$left" && isNULL "$right" && { echo 0  ; return ; } 
-	isNULL "$left"                    && { echo -1 ; return ; } 
-	                  isNULL "$right" && { echo 1  ; return ; } 
+        is-null "$left" && is-null "$right" && { echo 0  ; return ; }
+        is-null "$left"                     && { echo -1 ; return ; }
+                           is-null "$right" && { echo 1  ; return ; }
 
-	isNAT "$left" && isNAT "$right" && { order=$(orderNAT "$left" "$right") ; continue ; } 
-	isNAT "$left"                   && { echo -1 ; return ; } 
-	                 isNAT "$right" && { echo 1  ; return ; } 
-	                                   { order=$(orderSTRING "$left" "$right") ; continue ; } 
+        is-nat "$left" &&  is-nat "$right" && { order=$(order-nat "$left" "$right") ; continue ; }
+        is-nat "$left"                     && { echo -1 ; return ; }
+                           is-nat "$right" && { echo 1  ; return ; }
+                                              { order=$(order-string "$left" "$right") ; continue ; }
     done
 }
 
-# shellcheck disable=SC2206	# checked by "validate"; ok to expand prerel id's into array
+# shellcheck disable=SC2206     # checked by "validate"; ok to expand prerel id's into array
 function compare-version {
   local order
   validate-version "$1" V
@@ -182,7 +178,7 @@ function compare-version {
 
   [ -z "$prerel" ] && [ -z "$prerel_" ] && { echo 0  ; return ; }
   [ -z "$prerel" ]                      && { echo 1  ; return ; }
-		      [ -z "$prerel_" ] && { echo -1 ; return ; }
+                      [ -z "$prerel_" ] && { echo -1 ; return ; }
 
   # otherwise, compare the pre-release id's
 
@@ -234,7 +230,7 @@ function command-compare {
     *) usage-help ;;
   esac
 
-  set +u			# need unset array element to evaluate to null
+  set +u                        # need unset array element to evaluate to null
   compare-version "$v" "$v_"
   exit 0
 }

--- a/src/semver
+++ b/src/semver
@@ -2,10 +2,19 @@
 
 set -o errexit -o nounset -o pipefail
 
-SEMVER_REGEX="^[vV]?(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+NAT='0|[1-9][0-9]*'
+ALPHANUM='[0-9]*[A-Za-z-][0-9A-Za-z-]*'
+IDENT="$NAT|$ALPHANUM"
+FIELD='[0-9A-Za-z-]+'
+
+SEMVER_REGEX="\
+^[vV]?\
+($NAT)\\.($NAT)\\.($NAT)\
+(\\-(${IDENT})(\\.(${IDENT}))*)?\
+(\\+${FIELD}(\\.${FIELD})*)?$"
 
 PROG=semver
-PROG_VERSION=2.2.0
+PROG_VERSION="3.0.0-rc1"
 
 USAGE="\
 Usage:
@@ -16,35 +25,44 @@ Usage:
   $PROG --version
 
 Arguments:
-  <version>  A version must match the following regex pattern:
-             \"${SEMVER_REGEX}\".
-             In english, the version must match X.Y.Z(-PRERELEASE)(+BUILD)
-             where X, Y and Z are positive integers, PRERELEASE is an optional
-             string composed of alphanumeric characters, dots and hyphens and
-             BUILD is also an optional string composed of alphanumeric
-             characters, dots and hyphens.
+  <version>  A version must match the following regular expression:
+             \"${SEMVER_REGEX}\"
+             In English:
+	     -- The version must match X.Y.Z[-PRERELEASE][+BUILD]
+                where X, Y and Z are non-negative integers.
+	     -- PRERELEASE is a dot separated sequence of non-negative integers and/or
+	        identifiers composed of alphanumeric characters and hyphens (with
+		at least one non-digit). Numeric identifiers must not have leading
+		zeros. A hyphen (\"-\") introduces this optional part.
+	     -- BUILD is a dot separated sequence of identifiers composed of alphanumeric
+	        characters and hyphens. A plus (\"+\") introduces this optional part.
 
   <other_version>  See <version> definition.
 
-  <prerel>  String that must be composed of alphanumeric characters, dots and hyphens.
+  <prerel>  A string as defined by PRERELEASE above.
 
-  <build>   String that must be composed of alphanumeric characters, dots and hyphens.
+  <build>   A string as defined by BUILD above.
 
 Options:
   -v, --version          Print the version of this tool.
   -h, --help             Print this help message.
 
 Commands:
-  bump     Bump <version> by one of major, minor, patch, prerel, build
-           or a forced potentially conflicting version. The bumped version is
-           shown to stdout.
+  bump     Bump by one of major, minor, patch; zeroing or removing
+           subsequent parts. \"bump prerel\" sets the PRERELEASE part and
+	   removes any BUILD part. \"bump build\" sets the BUILD part.
+	   \"bump release\" removes any PRERELEASE or BUILD parts.
+           The bumped version is written to stdout.
 
   compare  Compare <version> with <other_version>, output to stdout the
            following values: -1 if <other_version> is newer, 0 if equal, 1 if
-           older.
+           older. The BUILD part is not used in comparisons.
 
   get      Extract given part of <version>, where part is one of major, minor,
-           patch, prerel, build."
+           patch, prerel, build, or release.
+
+See also:
+  https://semver.org -- Semantic Versioning 2.0.0"
 
 function error {
   echo -e "$1" >&2
@@ -73,7 +91,7 @@ function validate-version {
       local minor=${BASH_REMATCH[2]}
       local patch=${BASH_REMATCH[3]}
       local prere=${BASH_REMATCH[4]}
-      local build=${BASH_REMATCH[6]}
+      local build=${BASH_REMATCH[8]}
       eval "$2=(\"$major\" \"$minor\" \"$patch\" \"$prere\" \"$build\")"
     else
       echo "$version"
@@ -83,34 +101,92 @@ function validate-version {
   fi
 }
 
+function isNAT {
+    [[ "$1" =~ ^($NAT)$ ]]
+}
+
+function isNULL {
+    [ -z "$1" ]
+}
+
+function orderNAT {
+    [ "$1" -lt "$2" ] && { echo -1 ; return ; }
+    [ "$1" -gt "$2" ] && { echo 1 ; return ; }
+    echo 0
+}
+
+function orderSTRING {
+    [[ $1 < $2 ]] && { echo -1 ; return ; }
+    [[ $1 > $2 ]] && { echo 1 ; return ; }
+    echo 0
+}
+
+# given two (named) arrays containing NAT and/or ALPHANUM fields, compare them
+# one by one according to semver 2.0.0 spec. Return -1, 0, 1 if left array ($1)
+# is less-than, equal, or greater-than the right array ($2).  The longer array
+# is considered greater-than the shorter if the shorter is a prefix of the longer.
+#
+function compare-fields {
+    local l="$1[@]"
+    local r="$2[@]"
+    local leftfield=( "${!l}" )
+    local rightfield=( "${!r}" )
+    local left
+    local right
+
+    local i=$(( -1 ))
+    local order=$(( 0 ))
+
+    while true
+    do
+	[ $order -ne 0 ] && { echo $order ; return ; }
+
+	: $(( i++ ))
+	left="${leftfield[$i]}"
+	right="${rightfield[$i]}"
+
+	isNULL "$left" && isNULL "$right" && { echo 0  ; return ; } 
+	isNULL "$left"                    && { echo -1 ; return ; } 
+	                  isNULL "$right" && { echo 1  ; return ; } 
+
+	isNAT "$left" && isNAT "$right" && { order=$(orderNAT "$left" "$right") ; continue ; } 
+	isNAT "$left"                   && { echo -1 ; return ; } 
+	                 isNAT "$right" && { echo 1  ; return ; } 
+	                                   { order=$(orderSTRING "$left" "$right") ; continue ; } 
+    done
+}
+
+# shellcheck disable=SC2206	# checked by "validate"; ok to expand prerel id's into array
 function compare-version {
+  local order
   validate-version "$1" V
   validate-version "$2" V_
 
-  # MAJOR, MINOR and PATCH should compare numerically
-  for i in 0 1 2; do
-    local diff=$((${V[$i]} - ${V_[$i]}))
-    if [[ $diff -lt 0 ]]; then
-      echo -1; return 0
-    elif [[ $diff -gt 0 ]]; then
-      echo 1; return 0
-    fi
-  done
+  # compare major, minor, patch
 
-  # PREREL should compare with the ASCII order.
-  if [[ -z "${V[3]}" ]] && [[ -n "${V_[3]}" ]]; then
-    echo 1; return 0;
-  elif [[ -n "${V[3]}" ]] && [[ -z "${V_[3]}" ]]; then
-    echo -1; return 0;
-  elif [[ -n "${V[3]}" ]] && [[ -n "${V_[3]}" ]]; then
-    if [[ "${V[3]}" > "${V_[3]}" ]]; then
-      echo 1; return 0;
-    elif [[ "${V[3]}" < "${V_[3]}" ]]; then
-      echo -1; return 0;
-    fi
-  fi
+  local left=( "${V[0]}" "${V[1]}" "${V[2]}" )
+  local right=( "${V_[0]}" "${V_[1]}" "${V_[2]}" )
 
-  echo 0
+  order=$(compare-fields left right)
+  [ "$order" -ne 0 ] && { echo "$order" ; return ; }
+
+  # compare pre-release ids when M.m.p are equal
+
+  local prerel="${V[3]:1}"
+  local prerel_="${V_[3]:1}"
+  local left=( ${prerel//./ } )
+  local right=( ${prerel_//./ } )
+
+  # if left and right have no pre-release part, then left equals right
+  # if only one of left/right has pre-release part, that one is less than simple M.m.p
+
+  [ -z "$prerel" ] && [ -z "$prerel_" ] && { echo 0  ; return ; }
+  [ -z "$prerel" ]                      && { echo 1  ; return ; }
+		      [ -z "$prerel_" ] && { echo -1 ; return ; }
+
+  # otherwise, compare the pre-release id's
+
+  compare-fields left right
 }
 
 function command-bump {
@@ -158,6 +234,7 @@ function command-compare {
     *) usage-help ;;
   esac
 
+  set +u			# need unset array element to evaluate to null
   compare-version "$v" "$v_"
   exit 0
 }


### PR DESCRIPTION
Change summary:

1. SEMVER_REGEX

SEMVER_REGEX now enforces the rule that numeric id's in the pre-release part
may not have leading zero's.  Alphanumeric id's may have leading zeros.
With the exception of the (permissive) acceptance of a leading "v" or "V",
the RE is now compliant.

The re-written SEMVER_REGEX has been decomposed into defined
sub-expressions to ease understanding of the code and to remove
redundancies.  However, the usage message and public API retain the fully
expanded RE which is now longer and more complex.

Because of changes in the RE groupings, the indexes to captured groups
in BASH_REMATCH have changed.

The SEMVER_REGEX is essentially the same as the Perl version published
by semver.org.  See: semver.org and https://regex101.com/r/vkijKf/1/

The only deltas are that:
1. The "\d" digit character class is not used.  "[0-9]" is used here
   instead.
2. Paren's used to capture sub-matches capture the leading "-" and "+"
   here due to implementation needs of the script. The semver.org regex
   has paren's to capture the pre-release and build parts without these
   leading characters.

The two RE's express exactly the same set of version strings.

2. Version Comparison

The comparison command has been completely reworked to comply with the
2.0.0 spec.  In particular, pre-release ids are compared one against the
other, the comparison is based on whether or not they are numeric or
not, numeric vs. non-numeric always has numeric at lower precedence, the
longer of otherwise identical pre-release parts has higher precedence.

The comparison implementation has been factored into functions.
The general style is the use of "truth tables" rather than
if-then-else statements. Efficiency is really not important in this
tool, but opportunities exist to boost/reorder/eliminate the lines
in the truth tables (e.g. boost the nat-2-nat compare) to shorten the
code and execution paths. Readability--more important here!--would
suffer.

The code to pass arrays as parameters to "compare-fields" is a bit
magic, but references to the technique can be found on the web.
See, e.g. https://stackoverflow.com/questions/11180714/how-to-iterate-over-an-array-using-indirect-reference

Lint complaints about non-quoted expansion in "compare-version" is
surpressed because we need word expansion to form the arrays of
pre-release fields.  The safety is insured due to the validation of the
contents by regular expression matching in "validate-version".

3. Documentation updates to semver 2.0.0 semantics

4. Version

The version has been set to 3.0.0-rc1 as this change to semver has
non-backward compatible changes:
1. Certain versions compare differently due to ident by ident comparison
   and the use of numeric vs ASCII sort order compares.
2. Certain versions are now rejected for not matching the semver regex:
   leading zeros are not allowed.

5. Testing

This commit has been tested against the "bats" unit tests and all tests
pass.  However, the commit does not depend on these tests being present.
The commit can be merged/rebased onto the unit test commit or
vice-versa.

Note that without this commit applied to the release branch (master),
the bats unit tests will fail (showing non-compliance with 2.0.0).
Applying this release makes the tests pass.