### PR TITLE
add diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ Commands:
            following values: -1 if <other_version> is newer, 0 if equal, 1 if
            older. The BUILD part is not used in comparisons.
 
+  diff     Compare <version> with <other_version>, output to stdout the
+           difference between two versions by the release type (MAJOR, MINOR,
+           PATCH, PRERELEASE, BUILD).
+
   get      Extract given part of <version>, where part is one of major, minor,
            patch, prerel, build, or release.
 
@@ -123,7 +127,7 @@ Extract version part
     $ semver get release 1.2.3-rc.4+build.567
     1.2.3
     $ semver get prerel 1.2.3+build.568
-    
+
     $ semver get prerel 1.2.3-rc.4+build.569
     rc.4
     $ semver get prerel 1.2.3-rc-4+build.570

--- a/src/semver
+++ b/src/semver
@@ -14,7 +14,7 @@ SEMVER_REGEX="\
 (\\+${FIELD}(\\.${FIELD})*)?$"
 
 PROG=semver
-PROG_VERSION="3.0.0"
+PROG_VERSION="3.1.0"
 
 USAGE="\
 Usage:
@@ -57,6 +57,10 @@ Commands:
   compare  Compare <version> with <other_version>, output to stdout the
            following values: -1 if <other_version> is newer, 0 if equal, 1 if
            older. The BUILD part is not used in comparisons.
+
+  diff     Compare <version> with <other_version>, output to stdout the
+           difference between two versions by the release type (MAJOR, MINOR,
+           PATCH, PRERELEASE, BUILD).
 
   get      Extract given part of <version>, where part is one of major, minor,
            patch, prerel, build, or release.
@@ -235,6 +239,35 @@ function command-compare {
   exit 0
 }
 
+function command-diff {
+  validate-version "$1" v1_parts
+  # shellcheck disable=SC2154
+  local v1_major="${v1_parts[0]}"
+  local v1_minor="${v1_parts[1]}"
+  local v1_patch="${v1_parts[2]}"
+  local v1_prere="${v1_parts[3]}"
+  local v1_build="${v1_parts[4]}"
+
+  validate-version "$2" v2_parts
+  # shellcheck disable=SC2154
+  local v2_major="${v2_parts[0]}"
+  local v2_minor="${v2_parts[1]}"
+  local v2_patch="${v2_parts[2]}"
+  local v2_prere="${v2_parts[3]}"
+  local v2_build="${v2_parts[4]}"
+
+  if [ "${v1_major}" != "${v2_major}" ]; then
+    echo "major"
+  elif [ "${v1_minor}" != "${v2_minor}" ]; then
+    echo "minor"
+  elif [ "${v1_patch}" != "${v2_patch}" ]; then
+    echo "patch"
+  elif [ "${v1_prere}" != "${v2_prere}" ]; then
+    echo "prerelease"
+  elif [ "${v1_build}" != "${v2_build}" ]; then
+    echo "build"
+  fi
+}
 
 # shellcheck disable=SC2034
 function command-get {
@@ -274,5 +307,6 @@ case $1 in
   bump) shift; command-bump "$@";;
   get) shift; command-get "$@";;
   compare) shift; command-compare "$@";;
+  diff) shift; command-diff "$@";;
   *) echo "Unknown arguments: $*"; usage-help;;
 esac

--- a/test/semver_2.0.0.bats
+++ b/test/semver_2.0.0.bats
@@ -18,7 +18,7 @@ SEMVER="src/semver"
 #	A normal version number MUST take the form X.Y.Z where X, Y, and Z are non-negative
 #	integers, and MUST NOT contain leading zeroes. X is the major version, Y is the minor
 #	version, and Z is the patch version. Each element MUST increase numerically.
-#	For instance: 1.9.0 -> 1.10.0 -> 1.11.0.	
+#	For instance: 1.9.0 -> 1.10.0 -> 1.11.0.
 
 @test "normal version" {
 	result="$($SEMVER bump release 1.9.0)"
@@ -157,27 +157,27 @@ SEMVER="src/semver"
 }
 
 @test "bump invalid character in pre-release" {
-	run $SEMVER bump prerel "x.=.z.92" "1.0.0" 
+	run $SEMVER bump prerel "x.=.z.92" "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
 @test "bump empty identifier in pre-release (embedded)" {
-	run $SEMVER bump prerel "x.7.z..92" "1.0.0" 
+	run $SEMVER bump prerel "x.7.z..92" "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
 @test "bump empty identifier in pre-release (leading)" {
-	run $SEMVER bump prerel ".x.7.z.92" "1.0.0" 
+	run $SEMVER bump prerel ".x.7.z.92" "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
 @test "bump empty identifier in pre-release (trailing)" {
-	run $SEMVER bump prerel "x.7.z.92." "1.0.0" 
+	run $SEMVER bump prerel "x.7.z.92." "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
 @test "bump pre-release to invalid version" {
-	run $SEMVER bump prerel "x.7.z.92" "1.00.0" 
+	run $SEMVER bump prerel "x.7.z.92" "1.00.0"
 	[ "$status" -eq 1 ]
 }
 
@@ -255,27 +255,27 @@ SEMVER="src/semver"
 }
 
 @test "bump invalid character in build-metadata: $" {
-	run $SEMVER bump build "7.z$.92" "1.0.0" 
+	run $SEMVER bump build "7.z$.92" "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
 @test "bump invalid character in build-metadata: _" {
-	run $SEMVER bump build "7.z.92._" "1.0.0" 
+	run $SEMVER bump build "7.z.92._" "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
 @test "bump empty identifier in build-metadata (embedded)" {
-	run $SEMVER bump build "7.z..92" "1.0.0" 
+	run $SEMVER bump build "7.z..92" "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
 @test "bump empty identifier in build-metadata (leading)" {
-	run $SEMVER bump build ".x.7.z.92" "1.0.0" 
+	run $SEMVER bump build ".x.7.z.92" "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
 @test "bump empty identifier in build-metadata (trailing)" {
-	run $SEMVER bump build "z.92." "1.0.0" 
+	run $SEMVER bump build "z.92." "1.0.0"
 	[ "$status" -eq 1 ]
 }
 
@@ -381,3 +381,27 @@ SEMVER="src/semver"
 	[ "$result" = "0" ]
 }
 
+@test "diff versions (major)" {
+	result="$($SEMVER diff 1.2.3 2.3.4)"
+	[ "$result" = "major" ]
+}
+
+@test "diff versions (minor)" {
+	result="$($SEMVER diff 1.2.3 1.3.4)"
+	[ "$result" = "minor" ]
+}
+
+@test "diff versions (patch)" {
+	result="$($SEMVER diff 1.2.3 1.2.4)"
+	[ "$result" = "patch" ]
+}
+
+@test "diff versions (prerelease)" {
+	result="$($SEMVER diff 1.2.3-alpha 1.2.3-beta)"
+	[ "$result" = "prerelease" ]
+}
+
+@test "diff versions (equal)" {
+	result="$($SEMVER diff 1.2.3 1.2.3)"
+	[ "$result" = "" ]
+}


### PR DESCRIPTION
Adds a handy command to get the difference between two versions by release type. E.g.

```
semver diff 1.2.3 2.3.4 => "major"
```