### PR TITLE
docs: add github action badge for unit tests and linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It can be combined with `git` pre-commit hooks to guarantee correct versioning.
 
 [semver]: https://github.com/mojombo/semver
 
-[![Build Status](https://travis-ci.org/fsaintjacques/semver-tool.svg?branch=master)](https://travis-ci.org/fsaintjacques/semver-tool)
+[![Unit Tests and Linters](https://github.com/fsaintjacques/semver-tool/actions/workflows/ci.yaml/badge.svg)](https://github.com/fsaintjacques/semver-tool/actions/workflows/ci.yaml)
 [![Stable Version](https://img.shields.io/github/tag/fsaintjacques/semver-tool.svg)](https://github.com/fsaintjacques/semver-tool/tree/3.2.0)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg?style=flat)](https://github.com/fsaintjacques/semver-tool/blob/develop/LICENSE)
 


### PR DESCRIPTION
issues: #48

Tested manually.

N.B.  This PR does not address removing code from the previous CI site (Travis).  The badge, however, is gone.
N.B.  This PR does not touch the github CI code (triggers, labels, etc).

Change does not imply a new release.

If @fsaintjacques does not accept this PR in the next few days, I will accept it myself as it is one liner to the docs and easily reversible.