### PR TITLE
docs: replace "tag" badge with "release" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ It can be combined with `git` pre-commit hooks to guarantee correct versioning.
 [semver]: https://github.com/mojombo/semver
 
 [![Unit Tests and Linters](https://github.com/fsaintjacques/semver-tool/actions/workflows/ci.yaml/badge.svg)](https://github.com/fsaintjacques/semver-tool/actions/workflows/ci.yaml)
-[![Stable Version](https://img.shields.io/github/tag/fsaintjacques/semver-tool.svg)](https://github.com/fsaintjacques/semver-tool/tree/3.2.0)
+[![GitHub release (latest by date)](https://img.shields.io/github/v/release/fsaintjacques/semver-tool)](https://github.com/fsaintjacques/semver-tool/releases/latest)
 [![License](https://img.shields.io/badge/license-GPL--3.0-blue.svg?style=flat)](https://github.com/fsaintjacques/semver-tool/blob/develop/LICENSE)
 
 


### PR DESCRIPTION
The release badge displays a label dynamically generated from the
latest github release.  Only stable (non pre-release) releases are
considered.  The URL/markdown reflects the recommended form according
to shields.io.

The "click-through" URL is likewise dynamic and points to the latest
release on github. That is, the label and URL are automatically kept
in sync. The previous "tag" badge used a static URL
that needed to be maintained to stay in sync with the dynamic label.

Note that "latest" is determined by date: what the github api
considers latest.

issues: #49