### PR TITLE
Github Action Example / CI Refactor

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,6 @@ jobs:
         uses: asdf-vm/actions/install@v1
         with:
           tool_versions: |
-            action-validator 0.1.2
             bats 1.3.0
             shellcheck 0.8.0
             semver 3.3.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,12 @@ jobs:
             shellcheck 0.8.0
             semver 3.3.0
 
-      - name: Display Help
+      - name: Display semver help
         run: |
+          echo "Use semver locally or in your workflow"
+          echo "asdf plugin add semver"
+          echo "asdf install semver latest"
+          echo "asdf global semver latest"
           semver --version
           semver --help
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,24 +1,39 @@
 name: Unit Tests and Linters
 
-# Run this workflow every time a new commit pushed to your repository
-on: push
-
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 jobs:
-  # Set the job key. The key is displayed as the job name
-  # when a job name is not provided
   test-lint:
-    # Name the Job
     name: Unit tests and Lint code base
-    # Set the type of machine to run on
     runs-on: ubuntu-latest
 
     steps:
-      # Checks out a copy of your repository on the ubuntu-latest machine
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+
+      - name: Install dependencies with asdf
+        uses: asdf-vm/actions/install@v1
+        with:
+          tool_versions: |
+            action-validator 0.1.2
+            bats v1.3.0
+            shellcheck 0.8.0
+            semver 3.3.0
+
+      - name: Display Help
+        run: |
+          semver --version
+          semver --help
+
+      - name: Shellcheck linter
+        run: |
+          shellcheck src/semver
+          shellcheck test/documentation-test
+
       - name: Unit tests
-        shell: bash
-        run: make test
-      - name: Linter
-        shell: bash
-        run: make lint
+        run: bats test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,11 +27,13 @@ jobs:
 
       - name: Display semver help
         run: |
-          echo "Use semver locally or in your workflow"
+          echo "Use semver locally or in your workflow!"
           echo "asdf plugin add semver"
           echo "asdf install semver latest"
           echo "asdf global semver latest"
+          echo "semver --version"
           semver --version
+          echo "semver --help"
           semver --help
 
       - name: Shellcheck linter

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           tool_versions: |
             action-validator 0.1.2
-            bats v1.3.0
+            bats 1.3.0
             shellcheck 0.8.0
             semver 3.3.0
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,42 @@ It can be combined with `git` pre-commit hooks to guarantee correct versioning.
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/fsaintjacques/semver-tool)](https://github.com/fsaintjacques/semver-tool/releases/latest)
 [![License](https://shields.io/badge/license-Apache%202-blue)](https://github.com/fsaintjacques/semver-tool/blob/master/LICENSE)
 
+installation
+-----
+
+The semver tool can be downloaded from github, made executable and added to your path with these commands:
+
+```bash
+# Download the script and save it to /usr/local/bin
+wget -O /usr/local/bin/semver \
+  https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+
+# Make script executable
+chmod +x /usr/local/bin/semver
+
+# Prove it works
+semver --version
+# semver: 3.2.0
+```
+
+The semver tool can also be installed with the [asdf version manager](https://asdf-vm.com/) with [this plugin](https://github.com/mathew-fleisch/asdf-semver), which automates the process of downloading and installing release binaries from github. With asdf already installed, use the following commands to install the semver tool
+
+```bash
+# Add the semver plugin to asdf
+asdf plugin add semver
+
+# Show all installable versions
+asdf list-all semver
+
+# Install specific version
+asdf install semver latest
+
+# Set a version globally (on your ~/.tool-versions file)
+asdf global semver latest
+
+# Now semver commands are available
+semver --version
+```
 
 usage
 -----

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ asdf global semver latest
 semver --version
 ```
 
+For an example of how to use semver in a github-action, checkout the [ci action](.github/workflows/ci.yaml) in this repository.
+
 usage
 -----
 


### PR DESCRIPTION
A while back I created an [asdf plugin for semver](https://github.com/mathew-fleisch/asdf-semver) and thought I could also contribute an example of using semver in a github action by installing with the [asdf action](https://github.com/asdf-vm/actions) by refactoring the .github/workflows/ci.yaml file in this repo. Rather than using docker to run bats and shellcheck, asdf can be used to install those as well. After adding bats, shellcheck and semver as "tool-versions" dependencies, display the semver version and help as a verification, lint the code with shellcheck and finally run bats tests. This action is also now configured to run on merges to master as well as commits in pull requests to master. 