### PR TITLE
Specify SPDX tag for semver

### DIFF
--- a/src/semver
+++ b/src/semver
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
 
 set -o errexit -o nounset -o pipefail
 

--- a/test/general.bats
+++ b/test/general.bats
@@ -47,3 +47,8 @@ SEMVER="src/semver"
 	run $SEMVER
 	[ "$status" -eq 1 ]
 }
+
+@test "ensure SPDX tag is present" {
+	run grep -E '^# SPDX-License-Identifier: Apache-2.0$' $SEMVER
+	[ "$status" -eq 0 ]
+}


### PR DESCRIPTION
The semver utility is not widely packaged by distributions. As such projects may wish to incorporate the script directly as a helper to support packaging and versioning of a project.

In such cases, it is important to ensure that the licence of the semver utility is maintained.

Provide an Apache-2.0 SPDX tag [0][1] within the semver script to ensure the licencing is clear.

[0] https://spdx.dev/ids/
[1] https://spdx.org/licenses/Apache-2.0.html

Signed-off-by: Kieran Bingham <kieran.bingham@ideasonboard.com>