### PR TITLE
feat: wrap the script in a Docker container to simplify its usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM alpine:latest
+LABEL maintainer="Manuel de la Peña"
+
+RUN set -x && \
+    apk update && \
+    apk upgrade && \
+    apk add \
+        bash && \
+    rm -rf /var/cache/apk/*
+
+ADD src/semver /usr/local/bin/semver
+
+ARG BUILD_VERSION
+ARG BUILD_DATE
+ARG SCHEMA_NAME
+ARG SCHEMA_VENDOR
+ARG BUILD_VCS_REF
+ARG BUILD_VCS_URL
+
+LABEL org.label-schema.schema-version=$BUILD_VERSION \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.name=$SCHEMA_NAME \
+    org.label-schema.vcs-ref=$BUILD_VCS_REF \
+    org.label-schema.vcs-ref=$BUILD_VCS_URL \
+    org.label-schema.vendor=$SCHEMA_VENDOR \
+    org.label-schema.version=$BUILD_VERSION
+
+ENTRYPOINT ["semver"]
+CMD [""]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ Most likely, you will want to insure that the directory containing `semver` is o
 
 See [installation alternatives](#installation-alternatives) below.
 
+Or you can use it with Docker:
+  
+```bash
+# Prove it works
+docker run --rm fsaintjacques/semver-tool:latest semver --version
+# semver: 3.4.0
+```
+
 usage
 -----
 


### PR DESCRIPTION
## What does this PR does?
It adds a Dockerfile and a few Make goals to build the docker image that wraps the execution of the shell script, making it possible to run it in a cross-platform manner.

## How to test it?
Simply running the following command will do the trick:

```shell
make build
docker run --rm docker.io/fsaintjacques/semver-tool:3.4.0 bump minor "1.1.0"
```

It should produce the `1.2.0` output

## Follow-ups
Not sure how you want to release the Docker image, that's why I'm not adding anything to the Github action. Probably a dedicated one listening for tags, using secrets for the Docker user/password?
